### PR TITLE
Fix mount paths to work on both macOS and Linux

### DIFF
--- a/features/feature-mount-dotai/devcontainer-feature.json
+++ b/features/feature-mount-dotai/devcontainer-feature.json
@@ -1,22 +1,22 @@
 {
   "id": "feature-mount-dotai",
   "name": "feature-mount-dotai",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "postStartCommand": "env RCRC=$HOME/.dotai/rcrc rcup",
   "waitFor": "postStartCommand",
   "mounts": [
     {
-      "source": "/Users/${localEnv:USER}/.dotai",
+      "source": "${localEnv:HOME}/.dotai",
       "target": "/home/dev/.dotai",
       "type": "bind"
     },
     {
-      "source": "/Users/${localEnv:USER}/.config/opencode",
+      "source": "${localEnv:HOME}/.config/opencode",
       "target": "/home/dev/.config/opencode",
       "type": "bind"
     },
     {
-      "source": "/Users/${localEnv:USER}/.config/amp",
+      "source": "${localEnv:HOME}/.config/amp",
       "target": "/home/dev/.config/amp",
       "type": "bind"
     }

--- a/features/feature-mount-dotfiles-local/devcontainer-feature.json
+++ b/features/feature-mount-dotfiles-local/devcontainer-feature.json
@@ -1,9 +1,9 @@
 {
   "id": "feature-mount-dotfiles-local",
   "name": "feature-mount-dotfiles-local",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "mounts": [
-    "type=bind,source=/Users/${localEnv:USER}/.aliases.local,target=/home/dev/.aliases.local,ro",
-    "type=bind,source=/Users/${localEnv:USER}/.gitconfig.local,target=/home/dev/.gitconfig.local,ro"
+    "type=bind,source=${localEnv:HOME}/.aliases.local,target=/home/dev/.aliases.local,ro",
+    "type=bind,source=${localEnv:HOME}/.gitconfig.local,target=/home/dev/.gitconfig.local,ro"
   ]
 }


### PR DESCRIPTION
Replace hardcoded `/Users/${localEnv:USER}` with `${localEnv:HOME}` in feature-mount-dotai and feature-mount-dotfiles-local so bind mounts resolve correctly on Linux hosts (where home is `/home/<user>`).