### PR TITLE
Remove Claude Code from base image

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -102,14 +102,13 @@ RUN <<-EOF
 	echo 'export PATH="${PATH}:/home/linuxbrew/.linuxbrew/share/google-cloud-sdk/bin:/home/${USERNAME}/.bun/bin"' >> ${HOME}/.zshrc.devcontainer
 	EOF
 
-ENV CLAUDE_CONFIG_DIR="${HOME}/.config/claude"
 ENV OPENCODE_EXPERIMENTAL_MARKDOWN=true
 
 RUN <<-EOF
 	# install agentic tools
 	set -eux
 
-	bun install -g @sourcegraph/amp opencode-ai @anthropic-ai/claude-code
+	bun install -g @sourcegraph/amp opencode-ai
 	EOF
 
 COPY --chmod=755 bin/xclip /usr/local/bin/xclip


### PR DESCRIPTION
▎ Summary                                                                                                  
                                                                                                             
  ▎ - Removed ENV CLAUDE_CONFIG_DIR from the Dockerfile                                                      
  ▎ - Removed @anthropic-ai/claude-code from bun install -g (kept amp and opencode-ai)
                                                                                                             
  ▎ Why                                                                                                    
                                                                                                           
  ▎ The base image sets CLAUDE_CONFIG_DIR=/home/dev/.config/claude and installs Claude Code via bun install  
  -g. This conflicts with projects using the official ghcr.io/anthropics/devcontainer-features/claude-code:1 
  devcontainer feature.                                                                                      
                                                                                                           
  ▎ The conflict: the image hardcodes CLAUDE_CONFIG_DIR to .config/claude, but projects bind-mount host      
  ~/.claude to the container's default ~/.claude path for credentials sharing. Claude Code looks at the wrong
   path, requiring a CLAUDE_CONFIG_DIR="" hack.                                                              
                                                                                                           
  ▎ Moving installation to the devcontainer feature lets each project control its own version and avoids the 
  config path mismatch.                         