### PR TITLE
Restore Claude Code installation in base image

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -108,7 +108,7 @@ RUN <<-EOF
 	# install agentic tools
 	set -eux
 
-	bun install -g @sourcegraph/amp opencode-ai
+	bun install -g @sourcegraph/amp opencode-ai @anthropic-ai/claude-code
 	EOF
 
 COPY --chmod=755 bin/xclip /usr/local/bin/xclip


### PR DESCRIPTION
The previous commit removed both CLAUDE_CONFIG_DIR and the Claude Code package. The env var removal was correct (it conflicted with bind mounts), but the package should stay — it's installed via bun consistently with the other agentic tools, and the official devcontainer feature just adds an unnecessary npm install.